### PR TITLE
Release/0.5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.5.1 (2024-04-03)
+--------------------------
+Add support for AWS China regions (#29)
+
 Version 0.5.0 (2024-02-02)
 --------------------------
 Update LICENSE to SLULA (#25)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ module "iglu_server" {
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | The maximum number of servers in this server-group | `number` | `2` | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | The minimum number of servers in this server-group | `number` | `1` | no |
 | <a name="input_patches_allowed"></a> [patches\_allowed](#input\_patches\_allowed) | Whether or not patches are allowed for published Iglu Schemas | `bool` | `true` | no |
+| <a name="input_private_ecr_registry"></a> [private\_ecr\_registry](#input\_private\_ecr\_registry) | The URL of an ECR registry that the sub-account has access to (e.g. '000000000000.dkr.ecr.cn-north-1.amazonaws.com.cn/') | `string` | `""` | no |
 | <a name="input_scale_down_cooldown_sec"></a> [scale\_down\_cooldown\_sec](#input\_scale\_down\_cooldown\_sec) | Time (in seconds) until another scale-down action can occur | `number` | `600` | no |
 | <a name="input_scale_down_cpu_threshold_percentage"></a> [scale\_down\_cpu\_threshold\_percentage](#input\_scale\_down\_cpu\_threshold\_percentage) | The average CPU percentage that we must be below to scale-down | `number` | `20` | no |
 | <a name="input_scale_down_eval_minutes"></a> [scale\_down\_eval\_minutes](#input\_scale\_down\_eval\_minutes) | The number of consecutive minutes that we must be below the threshold to scale-down | `number` | `60` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   module_name    = "iglu-server-ec2"
-  module_version = "0.5.0"
+  module_version = "0.5.1"
 
   app_name    = "iglu-server"
   app_version = var.app_version

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,25 @@ locals {
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
+locals {
+  is_aws_global = replace(data.aws_region.current.name, "cn-", "") == data.aws_region.current.name
+  iam_partition = local.is_aws_global ? "aws" : "aws-cn"
+
+  is_private_ecr_registry = var.private_ecr_registry != ""
+  private_ecr_registry_statement = [{
+    Action = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer"
+    ]
+    Effect = "Allow"
+    Resource = [
+      "*"
+    ]
+  }]
+  private_ecr_registry_statement_final = local.is_private_ecr_registry ? local.private_ecr_registry_statement : []
+}
+
 module "telemetry" {
   source  = "snowplow-devops/telemetry/snowplow"
   version = "0.5.0"
@@ -76,24 +95,25 @@ EOF
 resource "aws_iam_policy" "iam_policy" {
   name = var.name
 
-  policy = <<EOF
-{
-  "Version" : "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:PutLogEvents",
-        "logs:CreateLogStream",
-        "logs:DescribeLogStreams"
-      ],
-      "Resource": [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.cloudwatch_log_group_name}:*"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = concat(
+      local.private_ecr_registry_statement_final,
+      [
+        {
+          Effect = "Allow",
+          Action = [
+            "logs:PutLogEvents",
+            "logs:CreateLogStream",
+            "logs:DescribeLogStreams"
+          ],
+          Resource = [
+            "arn:${local.iam_partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.cloudwatch_log_group_name}:*"
+          ]
+        }
       ]
-    }
-  ]
-}
-EOF
+    )
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "policy_attachment" {
@@ -235,6 +255,10 @@ locals {
 
     container_memory = "${module.instance_type_metrics.memory_application_mb}m"
     java_opts        = var.java_opts
+
+    is_private_ecr_registry = local.is_private_ecr_registry
+    private_ecr_registry    = var.private_ecr_registry
+    region                  = data.aws_region.current.name
   })
 }
 

--- a/templates/user-data.sh.tmpl
+++ b/templates/user-data.sh.tmpl
@@ -5,6 +5,10 @@ sudo base64 --decode << EOF > $${CONFIG_DIR}/iglu-server.hocon
 ${config_b64}
 EOF
 
+%{ if is_private_ecr_registry }
+aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${private_ecr_registry}
+%{ endif ~}
+
 # Run the server setup
 set +e
 sudo docker run \
@@ -18,7 +22,7 @@ sudo docker run \
   --mount type=bind,source=$${CONFIG_DIR},target=/snowplow/config \
   --env JDK_JAVA_OPTIONS='${java_opts}' \
   --env ACCEPT_LIMITED_USE_LICENSE=${accept_limited_use_license} \
-  snowplow/iglu-server:${version} \
+  ${private_ecr_registry}snowplow/iglu-server:${version} \
   setup --config /snowplow/config/iglu-server.hocon
 set -e
 
@@ -41,7 +45,7 @@ sudo docker run \
   --env JDK_JAVA_OPTIONS='${java_opts}' \
   --env ACCEPT_LIMITED_USE_LICENSE=${accept_limited_use_license} \
   -p ${port}:${port} \
-  snowplow/iglu-server:${version} \
+  ${private_ecr_registry}snowplow/iglu-server:${version} \
   --config /snowplow/config/iglu-server.hocon
 
 ${telemetry_script}

--- a/variables.tf
+++ b/variables.tf
@@ -218,3 +218,11 @@ variable "user_provided_id" {
   type        = string
   default     = ""
 }
+
+# --- Image Repositories
+
+variable "private_ecr_registry" {
+  description = "The URL of an ECR registry that the sub-account has access to (e.g. '000000000000.dkr.ecr.cn-north-1.amazonaws.com.cn/')"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This PR updates the module so that it can be deployed into AWS China regions (specifically to fix the IAM partition to dynamically shift from `aws` to `aws-cn`.

I have also added support for private ECR registries as the traditional `docker pull` flow times out so users wanting to run these services in AWS China will need to first host the required images in their own ECR registry.